### PR TITLE
Fix routing issues

### DIFF
--- a/src/module/managers/queue-manager.ts
+++ b/src/module/managers/queue-manager.ts
@@ -46,6 +46,10 @@ export class QueueManager {
         return this._name;
     }
 
+    getQueue(): QueueInterface {
+        return this._queue;
+    }
+
     assert(): Observable<QueueManager> {
         const obs = Observable.fromPromise(this._ch.assertQueue(this.getName(), this._options));
         debug(`asserting queue ${this.getName()}...`);

--- a/test/fixtures/Messages.ts
+++ b/test/fixtures/Messages.ts
@@ -19,6 +19,37 @@ export class FooMessage implements MessageInterface {
 @Message({
     queue: AnotherQueue,
     exchange: UserExchange,
+    routingKey: 'basket',
+    filter: {
+        'content.action': 'edited'
+    }
+})
+export class BasketEditedMessage implements MessageInterface {
+
+    onMessage(message: RabbitMessage) {
+        return Observable.of({ ack: true });
+    }
+}
+
+@Message({
+    queue: AnotherQueue,
+    exchange: UserExchange,
+    routingKey: 'profile',
+    filter: {
+        'content.action': 'edited',
+        'content.foo': 'bar'
+    }
+})
+export class ProfileEditedMessage implements MessageInterface {
+
+    onMessage(message: RabbitMessage) {
+        return Observable.of({ ack: true });
+    }
+}
+
+@Message({
+    queue: AnotherQueue,
+    exchange: UserExchange,
     routingKey: 'user',
     filter: {
         'content.action': 'edited'

--- a/test/fixtures/Queues.ts
+++ b/test/fixtures/Queues.ts
@@ -1,6 +1,6 @@
 import { Queue } from '../../src/module/decorators';
 import { UserExchange, EventsExchange } from './Exchanges';
-import { MessageResult, QueueInterface } from '../../src/module/interfaces';
+import { MessageResult } from '../../src/module/interfaces';
 import { Observable } from 'rxjs';
 
 @Queue({
@@ -26,7 +26,7 @@ import { Observable } from 'rxjs';
         }
     ]
 })
-export class UserQueue implements QueueInterface {
+export class UserQueue {
     onAsserted() {
         return Observable.of(null);
     }
@@ -52,7 +52,7 @@ export class UserQueue implements QueueInterface {
         }
     ]
 })
-export class AnotherQueue implements QueueInterface {}
+export class AnotherQueue {}
 
 @Queue({
     name: 'worker',
@@ -60,4 +60,12 @@ export class AnotherQueue implements QueueInterface {}
         durable: true
     }
 })
-export class WorkerQueue implements QueueInterface {}
+export class WorkerQueue {}
+
+@Queue({
+    name: 'empty',
+    options: {
+        durable: true
+    }
+})
+export class EmptyQueue {}

--- a/test/integration/module.test.ts
+++ b/test/integration/module.test.ts
@@ -12,7 +12,7 @@ import {
     PokemonsMessage
 } from '../fixtures/Messages';
 import { MayonaiseService } from '../fixtures/Services';
-import { AnotherQueue, UserQueue, WorkerQueue } from '../fixtures/Queues';
+import { AnotherQueue, UserQueue, WorkerQueue, EmptyQueue } from '../fixtures/Queues';
 import { EventsExchange, UserExchange } from '../fixtures/Exchanges';
 import { RabbitMQModule } from '../../src/module';
 import { RabbitConnectionService } from '../../src/module/services';
@@ -35,7 +35,8 @@ export class RabbitMQIntegrationTest {
                 EventsExchange,
                 WorkerQueue,
                 UserQueue,
-                AnotherQueue
+                AnotherQueue,
+                EmptyQueue
             ],
             providers: [MayonaiseService],
             exports: [],
@@ -47,7 +48,6 @@ export class RabbitMQIntegrationTest {
             onStart() {
                 unit.object(this._connectionService).isInstanceOf(RabbitConnectionService);
                 unit.object(this._connectionService.connectionManager);
-                // unit.string(this._connectionService.connectionManager['uri']).is('amqp://username:*********@localhost:5672/%2Fmy_vhost');
                 unit.string(this._connectionService.connectionManager.uri).is('amqp://localhost:5672');
                 unit.object(this._connectionService.connection);
                 done();

--- a/test/unit/extension/init-extension.test.ts
+++ b/test/unit/extension/init-extension.test.ts
@@ -13,6 +13,8 @@ import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import { RabbitMQExt } from '../../../src/module/rabbitmq.extension';
 import { ConnectionManagerMock } from '../../mocks/ConnectionManager';
 
+// let errorHandler  = require('@hapiness/core/core').errorHandler;
+
 @suite('- Unit InitExtension')
 export class InitExtensionUnitTest {
     private ch: Channel;
@@ -118,5 +120,15 @@ export class InitExtensionUnitTest {
                 .catch(() => done())
         );
         connection.emit('error', new Error('Woops'));
+    }
+
+    @test('- Should test error on consumeQueue')
+    testConsumeError(done) {
+        const queueStub = {
+            getName: () => 'hello',
+            consume: () => Observable.throw(new Error('Cannot consume'))
+        };
+        RegisterAnnotations.consumeQueue(<any>queueStub, <any>{})
+        .subscribe((_) => done(), err => done(err));
     }
 }


### PR DESCRIPTION
Fixed some issues with the routing logic

- Don't consume queue if no message registered or missing onMessage function on queue (1)
- If filter is set on the @Message validate all values on the message: do not allow a partial match
- If we cannot match a message based on fields we don't match the message (2)

(1) This is to allow developers to only configure rabbitmq without consuming messages

(2) If we allow to match a message only on it's filter configuration we could match messages that are not sent to the right queue or routingKey. 
