### PR TITLE
Catch and send event after openConnection()

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,8 @@ To set up your development environment:
 [Back to top](#table-of-contents)
 
 ## Change History
+* v1.4.3 (2018-08-20)
+    * Emit RETRY_LIMIT_EXCEEDED error on ConnectionManager
 * v1.4.2 (2018-06-11)
     * Do not retry to connect if closing server
 * v1.4.1 (2018-05-31)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hapiness/rabbitmq",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hapiness/rabbitmq",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Hapiness module for rabbitmq",
   "main": "commonjs/index.js",
   "types": "index.d.ts",

--- a/src/module/rabbitmq.extension.ts
+++ b/src/module/rabbitmq.extension.ts
@@ -61,7 +61,9 @@ export class RabbitMQExt implements OnExtensionLoad, OnModuleInstantiated, OnShu
             connection
                 .connect()
                 .flatMap(() => RegisterAnnotations.bootstrap(module, connection))
-                .subscribe(() => {}, err => errorHandler(err));
+                .subscribe(() => {}, err => {
+                    errorHandler(err);
+                });
         });
 
         return RegisterAnnotations.bootstrap(module, connection);


### PR DESCRIPTION
The only error sent should RETRY_LIMIT_EXCEEDED as the openConnection() method will try to reconnect after an error.

This could be used by third parties to catch this and decide on how to handle it.